### PR TITLE
fix: vscodium name app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-search-provider",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Provide search results from vscode",
   "type": "module",
   "private": true,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -88,6 +88,8 @@ export default class VSCodeSearchProvider<
       "code",
       "code-insiders",
       "code-oss",
+      "codium",
+      "codium-insiders",
       "com.vscodium.codium",
       "com.vscodium.codium-insiders",
     ];


### PR DESCRIPTION
Hey, 
vscodium name app is wrong named in non-flatpak, so it can find it.