### PR TITLE
Add support for GNOME 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,6 @@
   "donations": {
     "github": "mrmarble"
   },
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "settings-schema": "org.gnome.shell.extensions.vscode-search-provider"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-search-provider",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Provide search results from vscode",
   "type": "module",
   "private": true,


### PR DESCRIPTION
The extension still appears to be functional in GNOME 49; the only change which I needed to make on my system to make the extension functional was to add 49 as a supported version.