### PR TITLE
Add opt in workspace type features and results sorting

### DIFF
--- a/gnome.d.ts
+++ b/gnome.d.ts
@@ -13,6 +13,12 @@ declare module "resource:///org/gnome/shell/ui/main.js" {
     export module searchController {
       export function addProvider(provider: AppSearchProvider): void;
       export function removeProvider(provider: AppSearchProvider): void;
+      export const _searchResults: {
+        _content: {
+          remove_child(child: Any): void;
+          insert_child_at_index(child: object, index: number): void;
+        };
+      };
     }
   }
 }
@@ -37,6 +43,8 @@ declare module "resource:///org/gnome/shell/ui/appDisplay.js" {
 
   export class AppSearchProvider {
     constructor(extension: Extension);
+
+    display: unknown;
 
     /**
      * Launch the search result.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-search-provider",
-  "version": "2.2.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-search-provider",
-      "version": "2.2.0",
+      "version": "2.4.0",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@girs/gjs": "^4.0.0-beta.5",
@@ -1395,6 +1395,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
       "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
         "@octokit/graphql": "^8.0.0",
@@ -1931,6 +1932,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.8.0.tgz",
       "integrity": "sha512-KgKQly1pv0l4ltcftP59uQZCi4HUYswCLbTqVZEJu7uLX8CTLyswqMLqLN+2QFz4jCptqWVV4SB7vdxcH2+0kQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.8.0",
         "@typescript-eslint/types": "7.8.0",
@@ -2116,6 +2118,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3727,6 +3730,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3783,6 +3787,7 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5645,6 +5650,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
       "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9055,6 +9061,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
       "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9534,6 +9541,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.1.1.tgz",
       "integrity": "sha512-qqJDBhbtHsjUEMsojWKGuL5lQFCJuPtiXKEIlFKyTzDDGTAE/oyvznaP8GeOr5PvcqBJ6LQz4JCENWPLeehSpA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^12.0.0",
         "@semantic-release/error": "^4.0.0",
@@ -10619,6 +10627,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "format:fix": "prettier --write .",
     "clean": "rm -rf dist && rm -f ${npm_package_name}.zip",
     "pack": "npm run clean && npm run build && cp metadata.json dist && cp -r schemas dist && cd dist && zip ../${npm_package_name}.zip -9r .",
-    "install-extension": "touch $XDG_CONFIG_HOME/local/share/gnome-shell/extensions/${npm_package_name}@${npm_package_config_domain} && rm -rf $XDG_CONFIG_HOME/local/share/gnome-shell/extensions/${npm_package_name}@${npm_package_config_domain} && mv dist $XDG_CONFIG_HOME/local/share/gnome-shell/extensions/${npm_package_name}@${npm_package_config_domain}",
+    "install-extension": "gnome-extensions install ${npm_package_name}.zip --force",
     "setup": "npm run pack && glib-compile-schemas ./dist/schemas && npm run install-extension",
     "debug": "dbus-run-session -- gnome-shell --nested --wayland",
     "prepare": "simple-git-hooks",

--- a/schemas/org.gnome.shell.extensions.vscode-search-provider.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.vscode-search-provider.gschema.xml
@@ -1,9 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <schema id="org.gnome.shell.extensions.vscode-search-provider" path="/org/gnome/shell/extensions/vscode-search-provider/">
+    <key name="override-results-order" type="b">
+      <default>false</default>
+      <summary>Boolean, whether to override the default search results order to prioritize VS Code workspaces. Requires disabling and re-enabling the extension to take effect.</summary>
+    </key>
     <key name="suffix" type="b">
       <default>true</default>
       <summary>Boolean, whether to show a suffix next to the workspace name. (Remote, Codespaces...)</summary>
+    </key>
+    <key name="include-dev-containers" type="b">
+      <default>true</default>
+      <summary>Boolean, whether to include dev containers in the workspace list.</summary>
+    </key>
+    <key name="include-code-spaces" type="b">
+      <default>true</default>
+      <summary>Boolean, whether to include code spaces in the workspace list.</summary>
+    </key>
+    <key name="include-github" type="b">
+      <default>true</default>
+      <summary>Boolean, whether to include GitHub Virtual Files Systems in the workspace list.</summary>
     </key>
   </schema>
 </schemalist>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,12 @@ export default class VSCodeSearchProviderExtension extends Extension {
     this._settings = this.getSettings();
     this.provider = new VSCodeSearchProvider(this);
     Main.overview.searchController.addProvider(this.provider);
+
+    if (this._settings?.get_boolean("override-results-order")) {
+      const searchResults = Main.overview.searchController._searchResults;
+      searchResults._content.remove_child(this.provider.display);
+      searchResults._content.insert_child_at_index(this.provider.display, 1);
+    }
   }
 
   disable() {

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -14,6 +14,8 @@ export default class ExamplePreferences extends ExtensionPreferences {
   _settings: Gio.Settings | null = null;
 
   fillPreferencesWindow(window: Window) {
+    // Create a settings object
+    window._settings = this.getSettings();
     // Create a preferences page, with a single group
     const page = new Adw.PreferencesPage({
       title: _("General"),
@@ -28,20 +30,68 @@ export default class ExamplePreferences extends ExtensionPreferences {
 
     page.add(group);
 
-    // Create a new preferences row
-    const row = new Adw.SwitchRow({
+    const overrideResultsOrder = new Adw.SwitchRow({
+      title: _("Override Results Order"),
+      subtitle: _(
+        "If enabled, the extension will override the default search results order to prioritize VS Code workspaces. Will place the results directly underneath applications. Requires disabling and re-enabling the extension to take effect.",
+      ),
+    });
+    group.add(overrideResultsOrder);
+    window._settings.bind(
+      "override-results-order",
+      overrideResultsOrder,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+
+    const showSuffix = new Adw.SwitchRow({
       title: _("Show Suffix"),
       subtitle: _(
         "Whether to show a suffix next to the workspace name. (Remote, Codespaces...)",
       ),
     });
-    group.add(row);
-
-    // Create a settings object and bind the row to the `show-indicator` key
-    window._settings = this.getSettings();
+    group.add(showSuffix);
     window._settings.bind(
       "suffix",
-      row,
+      showSuffix,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+
+    const includeDevContainers = new Adw.SwitchRow({
+      title: _("Include Dev Containers"),
+      subtitle: _("Whether to include dev containers in the workspace list."),
+    });
+    group.add(includeDevContainers);
+    window._settings.bind(
+      "include-dev-containers",
+      includeDevContainers,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+
+    const includeCodeSpaces = new Adw.SwitchRow({
+      title: _("Include Code Spaces"),
+      subtitle: _("Whether to include code spaces in the workspace list."),
+    });
+    group.add(includeCodeSpaces);
+    window._settings.bind(
+      "include-code-spaces",
+      includeCodeSpaces,
+      "active",
+      Gio.SettingsBindFlags.DEFAULT,
+    );
+
+    const includeGithub = new Adw.SwitchRow({
+      title: _("Include GitHub Virtual File Systems"),
+      subtitle: _(
+        "Whether to include GitHub Virtual File Systems in the workspace list.",
+      ),
+    });
+    group.add(includeGithub);
+    window._settings.bind(
+      "include-github",
+      includeGithub,
       "active",
       Gio.SettingsBindFlags.DEFAULT,
     );

--- a/tests/provider.spec.js
+++ b/tests/provider.spec.js
@@ -2,6 +2,12 @@ import { test } from "uvu";
 import * as assert from "uvu/assert";
 import Provider from "../src/provider";
 
+const findWorkspace = (provider, pathFragment, name) => {
+  return Object.values(provider.workspaces).find((workspace) => {
+    return workspace.path.includes(pathFragment) && workspace.name === name;
+  });
+};
+
 test("should return instance of provider", () => {
   const provider = new Provider();
   assert.instance(provider, Provider);
@@ -25,52 +31,75 @@ test("should decode uri", () => {
   );
 });
 
-test("should ignore dev-containers", () => {
-  const provider = new Provider();
-  const workspace = Object.keys(provider.workspaces).find((key) => {
-    return provider.workspaces[key].path.includes("dev-containers");
-  });
-
-  assert.ok(
-    typeof workspace === "undefined",
-    `expected undefined but got ${provider.workspaces[workspace]?.path}`,
-  );
-});
-
-test("should not add suffix if disabled", async () => {
-  const provider = new Provider();
-
-  const workspaceId = Object.keys(provider.workspaces).find((key) => {
-    return provider.workspaces[key].path.includes(
-      "codespaces+musical-umbrella",
-    );
-  });
-
-  const meta = await provider.getResultMetas([workspaceId]);
-
-  assert.equal(meta[0].name, "vscode-search-provider");
-});
-
 [
-  ["vscode-search-provider [Codespaces]", "codespaces+musical-umbrella"],
   ["vscode-search-provider [Remote]", "/ts/vscode-search-provider"],
-  ["vscode-search-provider [Github]", "/mrmarble/vscode-search-provider"],
   ["Marlin-2.0.x", "Marlin"],
 ].forEach(([name, path]) => {
   test(`should add suffix for ${name}`, async () => {
     const provider = new Provider({
       _settings: {
-        get_boolean: () => true,
+        get_boolean: (key) => key === "suffix",
       },
     });
 
-    const workspaceId = Object.keys(provider.workspaces).find((key) => {
-      return provider.workspaces[key].path.includes(path);
+    assert.ok(
+      findWorkspace(provider, path, name),
+      `workspace ${name}:${path} expected`,
+    );
+  });
+});
+
+[
+  [
+    "vscode-search-provider [Codespaces]",
+    "codespaces+musical-umbrella",
+    ["include-code-spaces", "suffix"],
+  ],
+  [
+    "vscode-search-provider",
+    "codespaces+musical-umbrella",
+    ["include-code-spaces"],
+  ],
+  [
+    "vscode-search-provider [Github]",
+    "/mrmarble/vscode-search-provider",
+    ["include-github", "suffix"],
+  ],
+  [
+    "vscode-search-provider",
+    "/mrmarble/vscode-search-provider",
+    ["include-github"],
+  ],
+  [
+    "typescript-node [Dev Container]",
+    "/workspaces/typescript-node",
+    ["include-dev-containers", "suffix"],
+  ],
+  [
+    "typescript-node",
+    "/workspaces/typescript-node",
+    ["include-dev-containers"],
+  ],
+].forEach(([name, path, enabledSettings]) => {
+  test(`should enable and disable workspace type for ${name}`, async () => {
+    // Check workspace does not exist when settings are disabled
+    let provider = new Provider();
+    assert.not.ok(
+      findWorkspace(provider, path, name),
+      `workspace ${name}:${path} should not be found when settings ${enabledSettings} are disabled`,
+    );
+
+    // Check workspace exists when settings are enabled
+    provider = new Provider({
+      _settings: {
+        get_boolean: (key) => enabledSettings.includes(key),
+      },
     });
 
-    const meta = await provider.getResultMetas([workspaceId]);
-
-    assert.equal(meta[0].name, name);
+    assert.ok(
+      findWorkspace(provider, path, name),
+      `workspace ${name}:${path} should be found when settings ${enabledSettings} are enabled`,
+    );
   });
 });
 


### PR DESCRIPTION
Big fan of the extension! I use this every day. There are a few features I have wanted for a while and I have implemented them on my personal branch.  I figured I would open this PR with the changes and you can decide if you want them in the main extension or not.

# Option to include and exclude certain types of workspaces.
 
I am a big user of dev containers. The current implementation just completely turns this off, and I am not entirely sure why, as enabling them works fine for me. I figured this meant some people requested they not show up in the list, so I opted to make them configurable. Since I was in there, I did the same pattern for codespaces and github file system workspaces.

# Prioritizing Search Results

I probably use the search option to find vscode workspaces more than anything else besides apps. Unfortunately, this extension always adds these results as the last category. I researched how a few other extensions made their search results "prioritized" over the other ones, and this is how they did it. I also make this configurable, and default to off.

# Changes to the Installation Script

Opted to use the `gnome-extensions install` command for installation instead. The existing way did not work for me, and this seemed like the recommended approach from other repos as far as I could tell.

Made a few other small changes here and there because I was planning on maintaining these features just for myself, and I like certain coding patterns slightly more. Had I intended to always open this PR I probably would have refrained from making them. Let me know if you feel like any of them need to be rolled back!

Let me know if you have any questions! If you think these features are not something you want to add, feel free to close.

<img width="572" height="389" alt="image" src="https://github.com/user-attachments/assets/e1728ed5-af38-4913-bf04-3539a1b9f3f4" />
