### PR TITLE
Fix default selection when using override-results-order

### DIFF
--- a/gnome.d.ts
+++ b/gnome.d.ts
@@ -14,6 +14,7 @@ declare module "resource:///org/gnome/shell/ui/main.js" {
       export function addProvider(provider: AppSearchProvider): void;
       export function removeProvider(provider: AppSearchProvider): void;
       export const _searchResults: {
+        _providers: AppSearchProvider[];
         _content: {
           remove_child(child: unknown): void;
           insert_child_at_index(child: unknown, index: number): void;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,8 +15,12 @@ export default class VSCodeSearchProviderExtension extends Extension {
 
     if (this._settings?.get_boolean("override-results-order")) {
       const searchResults = Main.overview.searchController._searchResults;
+      // Rearrange the search results to put our provider just after apps.
       searchResults._content.remove_child(this.provider.display);
       searchResults._content.insert_child_at_index(this.provider.display, 1);
+      // Switch the providers order so it selects the first item in this provider by default.
+      searchResults._providers.splice(1, 0, this.provider);
+      searchResults._providers.pop();
     }
   }
 


### PR DESCRIPTION
Fixes issue where vscode-search-provider records would display above other search results appropriately, but the default selected item after searching would be the first record of whatever the next provider is.

Again, seems like there should be an easier way to accomplish this, but I can't find one for the life of me.